### PR TITLE
fix: Add error handling for post_message() to prevent infinite Slack retries

### DIFF
--- a/terraform/lambda_code/src/services/slack_event_handler.py
+++ b/terraform/lambda_code/src/services/slack_event_handler.py
@@ -93,7 +93,18 @@ def handle_app_mention(event_data: dict) -> dict:
     response = agent(clean_text)
 
     # 応答を同じチャンネルに送信
-    post_message(channel, str(response))
+    try:
+        post_message(channel, str(response))
+    except Exception as e:
+        # Slack へのメッセージ送信に失敗しても、Lambda は成功として返す
+        # これにより、Slack の無限再送を防ぐ
+        print(f"Slack へのメッセージ送信に失敗しました: {e}")
+        return {
+            'success': False,
+            'message': f'Slack へのメッセージ送信に失敗: {str(e)}',
+            'channel': channel,
+            'response': str(response)
+        }
 
     return {
         'success': True,


### PR DESCRIPTION
Fixes #6

Added error handling around the `post_message()` call at line 96 in `slack_event_handler.py` to prevent infinite retry loops from Slack.

## Changes
- Wrapped `post_message()` in a try-except block
- Added error logging that doesn't cause Lambda failure
- Returns appropriate error response while preventing Slack event retries

Generated with [Claude Code](https://claude.ai/code)